### PR TITLE
style: email template

### DIFF
--- a/packages/notifications/src/templates/otp-verification.tsx
+++ b/packages/notifications/src/templates/otp-verification.tsx
@@ -5,7 +5,7 @@ export const OTPTemplate = ({ code }: { code: number }) => {
     <div>
       <p>Hello,</p>
       <p>
-        Your one-time password for verifying your email address is
+        Your one-time password for verifying your email address is&nbsp;
         <strong>{code}</strong>.&nbsp;
       </p>
     </div>


### PR DESCRIPTION
Adding an extra space in between the verification code and the `is` word.

### Issues,
<img width="386" alt="Screenshot 2024-01-22 at 16 38 20" src="https://github.com/cubik-so/cubik/assets/5622951/4af91128-7da6-4e09-aea8-30cbfeeff7ef">
